### PR TITLE
Avoid not enough arguments TypeError

### DIFF
--- a/dom-pixels.js
+++ b/dom-pixels.js
@@ -10,7 +10,7 @@ module.exports = function getPixels(url, cb) {
     canvas.width = img.width
     canvas.height = img.height
     var context = canvas.getContext("2d")
-    context.drawImage(img)
+    context.drawImage(img, 0, 0)
     var pixels = context.getImageData(0, 0, img.width, img.height)
     cb(null, ndarray.ctor(new Uint8Array(pixels.data), [img.height, img.width, 4], [4*img.width, 4, 1], 0))
   }


### PR DESCRIPTION
Chrome requires x/y arguments otherwise it will throw: `Uncaught TypeError: Not enough arguments`. Thanks!
