### PR TITLE
Added support for buffers. Fixes #4

### DIFF
--- a/dom-pixels.js
+++ b/dom-pixels.js
@@ -120,7 +120,10 @@ module.exports = function getPixels(url, type, cb) {
       httpGif(url, cb)
     break
     default:
-      if(url.indexOf('data:image/gif;') === 0) {
+      if(Buffer.isBuffer(url)) {
+        var dataURI = 'data:' + type + ';base64,' + url.toString('base64')
+        defaultImage(dataURI, cb)
+      } else if(url.indexOf('data:image/gif;') === 0) {
         dataGif(url, cb)
       } else {
         defaultImage(url, cb)

--- a/node-pixels.js
+++ b/node-pixels.js
@@ -125,7 +125,13 @@ module.exports = function getPixels(url, type, cb) {
     cb = type
     type = ''
   }
-  if(url.indexOf('data:') === 0) {
+  if(Buffer.isBuffer(url)) {
+    if(!type) {
+      cb(new Error('Invalid file type'))
+      return
+    }
+    doParse(type, url, cb)
+  } else if(url.indexOf('data:') === 0) {
     try {
       var buffer = parseDataURI(url)
       if(buffer) {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,13 @@
   },
   "devDependencies": {
     "tape": "^2.12.3",
+    "brfs": "^1.2.0",
     "browserify": "^3.44.0",
     "beefy": "^1.1.0"
   },
   "scripts": {
     "test": "tap test/*.js",
-    "test-browser": "beefy --open --cwd test test.js"
+    "test-browser": "beefy --open --cwd test test.js -- -t brfs"
   },
   "repository": {
     "type": "git",

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 "use strict"
 var test = require("tape")
 
+var fs   = require("fs")
 var path = require("path")
 var getPixels = typeof window === "undefined" ?
   require("../node-pixels.js") :
@@ -127,5 +128,24 @@ test("data url", function(t) {
     }
     t.ok(true, 'data url opened without crashing')
     t.end()
+  })
+})
+
+test("get-pixels-buffer", function(t) {
+  fs.readFile(__dirname + "/test_pattern.png", function(err, buffer) {
+    if(err) {
+      t.error(err, "failed to read file")
+      t.end()
+      return
+    }
+    getPixels(buffer, "image/png", function(err, pixels) {
+      if(err) {
+        t.error(err, "failed to parse buffer")
+        t.end()
+        return
+      }
+      test_image(t, pixels)
+      t.end()
+    })
   })
 })


### PR DESCRIPTION
As with #4, I have a need to support loading from in-memory images in some `spritesmith` tests. This PR addresses that by adding `Buffer` support. In this PR:
- Added `Buffer` support (requires `type` specification)
- Added test for buffers
