### PR TITLE
Upgraded to latest jpeg-js to pick up JPEG parsing fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ndarray": "^1.0.13",
     "pngparse": "^1.1.4",
     "ndarray-pack": "^1.1.1",
-    "jpeg-js": "0.0.3",
+    "jpeg-js": "^0.1.1",
     "omggif": "^1.0.5",
     "node-bitmap": "0.0.1",
     "through": "^2.3.4",


### PR DESCRIPTION
In Ensighten/gulp.spritesmith#27 we are encountering JPEG parsing issues. This is being caused by a feature unsupported by an older version of `jpeg-js`. To remedy this, we need to upgrade the version of `jpeg-js` used by `get-pixels`. In this PR:

- Upgraded to `jpeg-js@0.1.1`
- Moved `jpeg-js` to `^` semver to pick up any future minor and patch changes