### PR TITLE
Fix broken HTTP support.

### DIFF
--- a/node-pixels.js
+++ b/node-pixels.js
@@ -149,12 +149,20 @@ module.exports = function getPixels(url, type, cb) {
       })
     }
   } else if(url.indexOf('http://') === 0 || url.indexOf('https://') === 0) {
-    request(url, function(err, response, body) {
+    request({url:url, encoding:null}, function(err, response, body) {
       if(err) {
         cb(err)
         return
       }
-      type = type || response.getHeader('content-type')
+      
+      type = type;
+      if(!type){
+        if(response.getHeader !== undefined){
+	  type = response.getHeader('content-type');
+	}else if(response.headers !== undefined){
+	  type = response.headers['content-type'];
+	}
+      }
       if(!type) {
         cb(new Error('Invalid content-type'))
         return

--- a/test/test.js
+++ b/test/test.js
@@ -129,3 +129,45 @@ test("get-pixels-buffer", function(t) {
     t.end()
   })
 })
+
+test("get-url png img", function(t) {
+  var url = "https://raw.githubusercontent.com/scijs/get-pixels/master/test/test_pattern.png";
+  getPixels(url, function(err, pixels){
+    if(err) {
+      console.log("Error:", err);
+      t.error(err, "failed to read web image data");
+      t.end();
+      return;
+    }
+    test_image(t, pixels);
+    t.end();
+  });
+});
+
+test("get-url jpg img", function(t) {
+  var url = "https://raw.githubusercontent.com/scijs/get-pixels/master/test/test_pattern.jpg";
+  getPixels(url, function(err, pixels){
+    if(err) {
+      console.log("Error:", err);
+      t.error(err, "failed to read web image data");
+      t.end();
+      return;
+    }
+    test_image(t, pixels);
+    t.end();
+  });
+});
+
+test("get-url gif img", function(t) {
+  var url = "https://raw.githubusercontent.com/scijs/get-pixels/master/test/test_pattern.gif";
+  getPixels(url, function(err, pixels){
+    if(err) {
+      console.log("Error:", err);
+      t.error(err, "failed to read web image data");
+      t.end();
+      return;
+    }
+    test_image(t, pixels.pick(0));
+    t.end();
+  });
+});


### PR DESCRIPTION
HTTP image support was completely broken. Added check for updated
Http.IncomingMessage.headers property in addition to checking for
getHeader(). Also explicitly set the encoding option to 'null' so that
the body value of the respons is always returned as a buffer preventing
the parsing libraries from failing to read Encoding headers properly.

Added three test cases to verify the fixes (one for each img type). They
are pointed to the github raw test images, which is safe for now.