### PR TITLE
Use phin instead of request

### DIFF
--- a/node-pixels.js
+++ b/node-pixels.js
@@ -8,7 +8,7 @@ var pack          = require('ndarray-pack')
 var GifReader     = require('omggif').GifReader
 var Bitmap        = require('node-bitmap')
 var fs            = require('fs')
-var request       = require('request')
+var phin          = require('phin')
 var mime          = require('mime-types')
 var parseDataURI  = require('parse-data-uri')
 
@@ -151,11 +151,13 @@ module.exports = function getPixels(url, type, cb) {
       })
     }
   } else if(url.indexOf('http://') === 0 || url.indexOf('https://') === 0) {
-    request({url:url, encoding:null}, function(err, response, body) {
+    phin({url:url}, function(err, response) {
       if(err) {
         cb(err)
         return
       }
+
+      var body = response.body;
 
       type = type;
       if(!type){

--- a/package.json
+++ b/package.json
@@ -7,17 +7,17 @@
     "test": "test"
   },
   "dependencies": {
-    "ndarray": "^1.0.13",
-    "pngjs": "^2.0.0",
-    "ndarray-pack": "^1.1.1",
+    "data-uri-to-buffer": "0.0.3",
     "jpeg-js": "^0.1.1",
-    "omggif": "^1.0.5",
-    "node-bitmap": "0.0.1",
-    "through": "^2.3.4",
-    "request": "^2.44.0",
-    "parse-data-uri": "^0.2.0",
     "mime-types": "^2.0.1",
-    "data-uri-to-buffer": "0.0.3"
+    "ndarray": "^1.0.13",
+    "ndarray-pack": "^1.1.1",
+    "node-bitmap": "0.0.1",
+    "omggif": "^1.0.5",
+    "parse-data-uri": "^0.2.0",
+    "phin": "^2.2.3",
+    "pngjs": "^2.0.0",
+    "through": "^2.3.4"
   },
   "devDependencies": {
     "tape": "^2.12.3",


### PR DESCRIPTION
[phin](https://github.com/Ethanent/phin) is a lightweight, fast HTTP module with no dependencies. (Using phin instead of request cuts down dependency tree size by 22!)