### PR TITLE
if content type isn't provided in the headers, determine the image type from the data

### DIFF
--- a/node-pixels.js
+++ b/node-pixels.js
@@ -11,6 +11,7 @@ var fs            = require('fs')
 var request       = require('request')
 var mime          = require('mime-types')
 var parseDataURI  = require('parse-data-uri')
+var imageType     = require('image-type');
 
 function handlePNG(data, cb) {
   var png = new PNG();
@@ -123,7 +124,33 @@ function doParse(mimeType, data, cb) {
     break
 
     default:
-      cb(new Error("Unsupported file type: " + mimeType))
+      var type = imageType(data);
+      if (type && type.mime) {
+        switch(type.mime) {
+          case 'image/png':
+            handlePNG(data, cb)
+            break
+
+          case 'image/jpg':
+          case 'image/jpeg':
+            handleJPEG(data, cb)
+            break
+
+          case 'image/gif':
+            handleGIF(data, cb)
+            break
+
+          case 'image/bmp':
+            handleBMP(data, cb)
+            break
+
+          default:
+            cb(new Error("Unsupported file type: " + mimeType))
+            break;
+        }
+      } else {
+        cb(new Error("Unsupported file type: " + mimeType))
+      }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "data-uri-to-buffer": "0.0.3",
+    "image-type": "^4.1.0",
     "jpeg-js": "^0.4.1",
     "mime-types": "^2.0.1",
     "ndarray": "^1.0.13",


### PR DESCRIPTION
I ran into a case where the content header returned from the server was just "image". this change defends against that case.