### PR TITLE
[CVE-2023-28155]: Replace request library with native fetch API

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "omggif": "^1.0.5",
     "parse-data-uri": "^0.2.0",
     "pngjs": "^3.3.3",
-    "request": "^2.44.0",
     "through": "^2.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
As per [CVE-2023-28155](https://github.com/advisories/GHSA-p8p7-x288-28g6), the request library is no longer maintained and contains security issues.

This PR is to replace the request library with the native fetch API that Node.js implemented since version 18. Node.js versions below that are not being [maintained ](https://endoflife.date/nodejs) anymore.

This will hopefully solve issue #62